### PR TITLE
Support gradle config cache

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 android {
     compileSdkVersion(30)
-    buildToolsVersion("30.0.2")
+    buildToolsVersion("30.0.3")
 
     defaultConfig {
         targetSdkVersion(30)

--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -2,5 +2,3 @@ android.useAndroidX=true
 
 # Gradle config cache
 org.gradle.unsafe.configuration-cache=true
-# Config cache WIP only - turn errors into warnings
-org.gradle.unsafe.configuration-cache-problems=warn

--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -1,1 +1,6 @@
 android.useAndroidX=true
+
+# Gradle config cache
+org.gradle.unsafe.configuration-cache=true
+# Config cache WIP only - turn errors into warnings
+org.gradle.unsafe.configuration-cache-problems=warn

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -9,14 +9,14 @@ pluginManagement {
         kotlin("jvm") version "1.5.10"
         kotlin("android") version "1.5.10"
         id("com.android.application") version "7.0.0-beta02"
-        id("si.kamino.version") version "2.0.1-SNAPSHOT"
+        id("si.kamino.version") version "3.0.1"
     }
 
     resolutionStrategy {
         eachPlugin {
             when (requested.id.id) {
                 "com.android.application" -> useModule("com.android.tools.build:gradle:7.0.0-beta02")
-                "si.kamino.version" -> useModule("si.kamino.gradle:android-version:2.0.1-SNAPSHOT")
+                "si.kamino.version" -> useModule("si.kamino.gradle:android-version:3.0.2-SNAPSHOT")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectGroup=si.kamino.gradle
 projectName=android-version
-projectVersion=2.1.2-SNAPSHOT
+projectVersion=3.0.2-SNAPSHOT
 
 POM_NAME=Android Version
 POM_DESCRIPTION=Android gradle plugin that for version managment

--- a/plugin/src/main/kotlin/si/kamino/gradle/VersionPlugin.kt
+++ b/plugin/src/main/kotlin/si/kamino/gradle/VersionPlugin.kt
@@ -33,7 +33,7 @@ class VersionPlugin : Plugin<Project> {
     }
 
     private fun createExtensions(project: Project): VersionExtension {
-        return project.extensions.create("androidVersion", VersionExtension::class.java, project)
+        return project.extensions.create("androidVersion", VersionExtension::class.java, project.objects)
     }
 
     private fun createTasks(project: Project) {

--- a/plugin/src/main/kotlin/si/kamino/gradle/extensions/VersionExtension.kt
+++ b/plugin/src/main/kotlin/si/kamino/gradle/extensions/VersionExtension.kt
@@ -2,7 +2,7 @@ package si.kamino.gradle.extensions
 
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Nested
 import si.kamino.gradle.extensions.code.BaseVersionCode
 import si.kamino.gradle.extensions.code.StaticVersionCode
@@ -12,16 +12,16 @@ import si.kamino.gradle.extensions.name.ExtendingVersion
 import java.io.Serializable
 import javax.inject.Inject
 
-abstract class VersionExtension @Inject constructor(private val project: Project) : Serializable {
+abstract class VersionExtension @Inject constructor(private val objectFactory: ObjectFactory) : Serializable {
 
     @get:Nested
-    var versionName: AbsVersionName = project.objects.newInstance(BaseVersionName::class.java)
+    var versionName: AbsVersionName = objectFactory.newInstance(BaseVersionName::class.java)
 
     @get:Nested
-    var versionCode: BaseVersionCode = project.objects.newInstance(StaticVersionCode::class.java)
+    var versionCode: BaseVersionCode = objectFactory.newInstance(StaticVersionCode::class.java)
 
     @get:Nested
-    val variants: NamedDomainObjectContainer<ExtendingVersion> = project.container(ExtendingVersion::class.java)
+    val variants: NamedDomainObjectContainer<ExtendingVersion> = objectFactory.domainObjectContainer(ExtendingVersion::class.java)
 
     fun versionName(action: Action<BaseVersionName>) {
         val instance = versionName
@@ -33,7 +33,7 @@ abstract class VersionExtension @Inject constructor(private val project: Project
     }
 
     fun <T : AbsVersionName> versionName(clazz: Class<T>, action: Action<T>) {
-        val instance = project.objects.newInstance(clazz)
+        val instance = objectFactory.newInstance(clazz)
         action.execute(instance)
         versionName = instance
     }
@@ -48,7 +48,7 @@ abstract class VersionExtension @Inject constructor(private val project: Project
     }
 
     fun <T : BaseVersionCode> versionCode(clazz: Class<T>, action: Action<T>) {
-        val instance = project.objects.newInstance(clazz)
+        val instance = objectFactory.newInstance(clazz)
         action.execute(instance)
         versionCode = instance
     }


### PR DESCRIPTION
Added support for gradle config cache and updated example project to use it. This meant that tasks must not use project (as well as other stuff) in execution time. 

Not sure about plugin dependency version in example in regards to publishing -> please check @blazsolar .