### PR TITLE
Made actual reading of files run in execution time

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectGroup=si.kamino.gradle
 projectName=android-version
-projectVersion=3.0.3
+projectVersion=3.1.0
 
 POM_NAME=Android Version
 POM_DESCRIPTION=Android gradle plugin that for version managment

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.android.tools.build:gradle:7.0.2")
+    compileOnly("com.android.tools.build:gradle:7.0.3")
 
     implementation(gradleApi())
     implementation(localGroovy())

--- a/plugin/src/main/kotlin/si/kamino/gradle/extensions/code/FileVersionCode.kt
+++ b/plugin/src/main/kotlin/si/kamino/gradle/extensions/code/FileVersionCode.kt
@@ -22,9 +22,6 @@ abstract class FileVersionCode @Inject constructor(objects: ObjectFactory) : Bas
             .filter { it.first == "version.code" }
             .first().second
             .toInt()
-            .also {
-                println("FileVersionCode read file, code: $it")
-            }
     }
 
     override fun getVersionCode(versionName: StaticVersion): Int {

--- a/plugin/src/main/kotlin/si/kamino/gradle/extensions/code/FileVersionCode.kt
+++ b/plugin/src/main/kotlin/si/kamino/gradle/extensions/code/FileVersionCode.kt
@@ -11,18 +11,27 @@ abstract class FileVersionCode @Inject constructor(objects: ObjectFactory) : Bas
     @get:InputFile
     val file: RegularFileProperty = objects.fileProperty()
 
-    private val versionCode = lazy {
+    // Note: can't use lazy {}, as it still gets evaluated in configuration time because of configuration cache / inputs change detection.
+    private var versionCode: Int? = null
+
+    private fun readVersionCode(): Int {
         // Make it nicer!
-        file.get().asFile.readLines()
+        return file.get().asFile.readLines()
             .map { it.split("=") }
             .map { it.first() to it.last() }
             .filter { it.first == "version.code" }
             .first().second
             .toInt()
+            .also {
+                println("FileVersionCode read file, code: $it")
+            }
     }
 
     override fun getVersionCode(versionName: StaticVersion): Int {
-        return versionCode.value
+        if (versionCode == null) {
+            versionCode = readVersionCode()
+        }
+        return versionCode!!
     }
 
 }

--- a/plugin/src/main/kotlin/si/kamino/gradle/extensions/name/FileVersion.kt
+++ b/plugin/src/main/kotlin/si/kamino/gradle/extensions/name/FileVersion.kt
@@ -19,9 +19,6 @@ abstract class FileVersion @Inject constructor(objects: ObjectFactory) : AbsVers
             .map { it.split("=") }
             .map { it.first() to it.last() }
             .toMap(LinkedHashMap())
-            .also {
-                println("FileVersion read properties: $it")
-            }
     }
 
     private fun requireProperties(): LinkedHashMap<String, String> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        kotlin("jvm") version "1.5.30"
+        kotlin("jvm") version "1.5.32"
         id("com.gradle.plugin-publish") version "0.15.0"
     }
 }


### PR DESCRIPTION
Made actual reading of files run in execution time instead of configuration time (even with lazy {}). Bumped gradle to 7.3.1 and AGP to 7.0.3.